### PR TITLE
Add ParseMessage overload using ReadOnlySequence avoiding conversion

### DIFF
--- a/src/Teltonika.AVL/AvlParser.cs
+++ b/src/Teltonika.AVL/AvlParser.cs
@@ -21,7 +21,13 @@ public class AvlParser
     /// </summary>
     public AvlMessage ParseMessage(ref ReadOnlyMemory<byte> buffer, bool verify = true)
     {
-        var reader = new SequenceReader<byte>(new ReadOnlySequence<byte>(buffer));
+        var memory = new ReadOnlySequence<byte>(buffer); 
+        return ParseMessage(ref memory, verify);
+    }
+
+    public AvlMessage ParseMessage(ref ReadOnlySequence<byte> buffer, bool verify = true)
+    {
+        var reader = new SequenceReader<byte>(buffer);
         var header = ReadHeader(ref reader);
 
         if (!CodecParsers.TryGetValue(header.CodecId, out var parser))


### PR DESCRIPTION
When using Kestrel as a TCP server, the server provides a ReadOnlySequence as a byte buffer. To utilize the ParseMessage function, this buffer needs to be converted to a ReadOnlyMemory object, which the ParseMessage function then converts back to a ReadOnlySequence. By adding an overload to the ParseMessage function, we can directly use it with a ReadOnlySequence.